### PR TITLE
feat: add JavaScript JSON parser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ replay_pid*
 
 
 **/.DS_STORE
+
+# Ignore node_modules
+node_modules/

--- a/Experiments/Battle of Json parsers/code/JavaScript/README.md
+++ b/Experiments/Battle of Json parsers/code/JavaScript/README.md
@@ -1,0 +1,15 @@
+# JavaScript JSON Parser Benchmark
+
+## Installation
+
+Before your first run, you need Node, npm, Deno and Bun.
+Deno and Bun are dependencies of the project and can be installed with `npm install`.
+
+## Usage
+
+Run the benchmark with `npm run test` to execute all environments (Node, Deno, Bun).
+You can also run benchmarks for specific environments:
+
+- For Node: `npm run test:node`
+- For Deno: `npm run test:deno`
+- For Bun: `npm run test:bun`

--- a/Experiments/Battle of Json parsers/code/JavaScript/index.js
+++ b/Experiments/Battle of Json parsers/code/JavaScript/index.js
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+
+const filename = new URL(
+  "../data/data_1k.json",
+  import.meta.url,
+).pathname.replaceAll("%20", " ");
+const jsonString = fs.readFileSync(filename, "utf8");
+
+const { avgTime, totalTime } = findAverageRunTime(() => JSON.parse(jsonString));
+
+console.log(
+  `Average parsing time with JSON.parse: ${avgTime.toFixed(
+    6,
+  )} seconds. Total ${totalTime.toFixed(6)} seconds.`,
+);
+
+function findAverageRunTime(testedFunction, repeats = 100) {
+  const times = [];
+
+  for (let i = 0; i < repeats; i++) {
+    const start = performance.now();
+
+    // RUN TEST
+    testedFunction();
+
+    const end = performance.now();
+
+    times.push((end - start) / 1000); // seconds
+  }
+
+  const avgTime = times.reduce((a, b) => a + b, 0) / repeats;
+  const totalTime = times.reduce((a, b) => a + b, 0);
+
+  return { avgTime, totalTime };
+}

--- a/Experiments/Battle of Json parsers/code/JavaScript/package-lock.json
+++ b/Experiments/Battle of Json parsers/code/JavaScript/package-lock.json
@@ -1,0 +1,289 @@
+{
+  "name": "javascript",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "javascript",
+      "version": "1.0.0",
+      "dependencies": {
+        "bun": "^1.2.20",
+        "deno": "^2.4.4"
+      }
+    },
+    "node_modules/@deno/darwin-arm64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/darwin-arm64/-/darwin-arm64-2.4.4.tgz",
+      "integrity": "sha512-mFxNliHJs3zHT515AoTICEYSv/zJTjXAU+QIZNXK3Yt1PaEHqbWYhxsMOp39Apb8ACgaAcGcJxPzsc6qecQVSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@deno/darwin-x64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/darwin-x64/-/darwin-x64-2.4.4.tgz",
+      "integrity": "sha512-3/15MyCithm77VFI9yesyLp+TLH5h3GQ0A2EEQISsWbJDWIOTMIAaL4suJHY0GMUKQZKOngoeyXyTqmGA/y0JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@deno/linux-arm64-glibc": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/linux-arm64-glibc/-/linux-arm64-glibc-2.4.4.tgz",
+      "integrity": "sha512-M0TnQI8j0JxI2A8nFkFMV4bGSzqFU25PX9ZR50OI58Eurp5WY+tmisAusWReVVPtgL7jaVpkS0sEIJyufVIxmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@deno/linux-x64-glibc": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/linux-x64-glibc/-/linux-x64-glibc-2.4.4.tgz",
+      "integrity": "sha512-KsNEe5nWgz54XdTkI06jgUXgXQzQ//mI2u24qPclSm/GNkAwAZMnzcBPnRSZ0gCbLJpy8nDc7fc+j2ITlLifVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@deno/win32-arm64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/win32-arm64/-/win32-arm64-2.4.4.tgz",
+      "integrity": "sha512-MPkhuVJVNF9PYiwrpRS0WfCwWxYmbB0CUgBE2+PC5FDbfmodfv+lv74w5HTPz2xITMdO4QqrOSSLz+JVCwjgSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@deno/win32-x64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/win32-x64/-/win32-x64-2.4.4.tgz",
+      "integrity": "sha512-3tZcX6Jx1T7OSyeSXmQpK7zjZwvcc4kTK7PXtkpLuDwFXmObOmsNdbMQXuOIXvcmLlnUnVYJEfEo63zBZWR11g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-aarch64": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.2.20.tgz",
+      "integrity": "sha512-zygk+yeaww9kBw2JBWwA13KyOKySxbnetms/WyRFaUYhxiuJHkzv1c6/Ou7sIHa9Gbq4fYQEhx88Ywy1wu2oTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.2.20.tgz",
+      "integrity": "sha512-k2akVmSvJHuzpwgwIU8ltary7EQbqlbvxgtYlVqYvnqUpRdRbkuJXAZhN5zuDNTftaG4l22Q/bX04tBB8Txmjg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64-baseline": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.2.20.tgz",
+      "integrity": "sha512-bxXZlLD6DJ8rc/Ht0Cgm0BH1AJVO/axOElXJP42LUUKQ/U4t3OKkFDbFiTPGphcy5teMLkoYl+a2Cz8P9q2gVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.2.20.tgz",
+      "integrity": "sha512-g+CzF02RzKgSmuEHNLoDTtiiQR33cEZWcd/tWR+24h92xe5wXuqQsV7vQJLR6e44BWkDOACpTIrfW4UAaHw4Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64-musl": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.2.20.tgz",
+      "integrity": "sha512-zB3aKckyUdKENLP+lm/PoXQPBTthJsY7dhYih+qVT95N29acLO2eWeSHgRkS7Pl2FV+mLJo9LvjRhC8oaSSoOw==",
+      "cpu": [
+        "aarch64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.2.20.tgz",
+      "integrity": "sha512-KJZ0zJKadKCD6EI/mBv/0PUysMpd1r4o3WhQ73PjCZx2w95Ka2fSBAIsy9e/rxc07D4LHr26nGyMmC1K8IcS6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-baseline": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.2.20.tgz",
+      "integrity": "sha512-xtYPn84ur9U7YaS0+rwjs6YMgSv5Z4gMnqPQ1QTLw92nt1v9Cw17YypVab4zUk222o5Y6kS3DRkDdSHBh8uQfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.2.20.tgz",
+      "integrity": "sha512-XPtQITGbJXgUrMXOJo3IShwQd3awB93ZIh5+4S3DF9Ek/lwXVSuueIIAfnveR/r9JRgEA5+g/1ZHVf1/3qaElg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl-baseline": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.2.20.tgz",
+      "integrity": "sha512-rANapFZRrgOTeotaf556iIxguyjQbensL6gT3cXZDnXG+aVhv65hSnjqzM7vfHxlzoXbAmoUkJOpce0qEg/HlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.2.20.tgz",
+      "integrity": "sha512-Jt4bAf30qG4SvnL6tO4QzZNbMjg5sLZHif22rZLwX7W6rWPAvgqyYdwDSGHN8Kkbe6KqV4DceyKQgRr83sU66Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64-baseline": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.2.20.tgz",
+      "integrity": "sha512-2291+pyVQ771zd8jgCNJ/jpPBaLJg/X7BWX06M9GpBNmC1tu3Rfr3LaWP8C/XTi80PZJnzNZGeMlcDhRY57y/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/bun": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/bun/-/bun-1.2.20.tgz",
+      "integrity": "sha512-1ZGQynT+jPOHLY4IfzSubjbWcXsY2Z+irhW5D8RKC0wQ6KG4MvtgniAYQbSFYINGg8Wb2ydx+WgAG2BdhngAfw==",
+      "cpu": [
+        "arm64",
+        "x64",
+        "aarch64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "bun": "bin/bun.exe",
+        "bunx": "bin/bunx.exe"
+      },
+      "optionalDependencies": {
+        "@oven/bun-darwin-aarch64": "1.2.20",
+        "@oven/bun-darwin-x64": "1.2.20",
+        "@oven/bun-darwin-x64-baseline": "1.2.20",
+        "@oven/bun-linux-aarch64": "1.2.20",
+        "@oven/bun-linux-aarch64-musl": "1.2.20",
+        "@oven/bun-linux-x64": "1.2.20",
+        "@oven/bun-linux-x64-baseline": "1.2.20",
+        "@oven/bun-linux-x64-musl": "1.2.20",
+        "@oven/bun-linux-x64-musl-baseline": "1.2.20",
+        "@oven/bun-windows-x64": "1.2.20",
+        "@oven/bun-windows-x64-baseline": "1.2.20"
+      }
+    },
+    "node_modules/deno": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/deno/-/deno-2.4.4.tgz",
+      "integrity": "sha512-uD357dB8icmaCuRy1xRbltEzA8/bbfMYtCV9W6cv8HDLw9mmfi57SwY4bpEw+wWGjk/2vbg3cIEEAE+2O8DnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "deno": "bin.cjs"
+      },
+      "optionalDependencies": {
+        "@deno/darwin-arm64": "2.4.4",
+        "@deno/darwin-x64": "2.4.4",
+        "@deno/linux-arm64-glibc": "2.4.4",
+        "@deno/linux-x64-glibc": "2.4.4",
+        "@deno/win32-arm64": "2.4.4",
+        "@deno/win32-x64": "2.4.4"
+      }
+    }
+  }
+}

--- a/Experiments/Battle of Json parsers/code/JavaScript/package.json
+++ b/Experiments/Battle of Json parsers/code/JavaScript/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "javascript",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test:node": "node index.js",
+    "test:deno": "deno run --allow-read index.js",
+    "test:bun": "bun index.js",
+    "test": "npm run test:node && npm run test:deno && npm run test:bun"
+  },
+  "type": "module",
+  "dependencies": {
+    "bun": "^1.2.20",
+    "deno": "^2.4.4"
+  }
+}


### PR DESCRIPTION
Should be run on the same system where the other tests were run, but these are the results from my machine:

```
Node.js v20.17.0
sindreboyum@Sindre-sin-MacBook-Pro JavaScript % npm test      

> javascript@1.0.0 test
> npm run test:node && npm run test:deno && npm run test:bun


> javascript@1.0.0 test:node
> node index.js

Average parsing time with JSON.parse: 0.053553 seconds. Total 5.355308 seconds.

> javascript@1.0.0 test:deno
> deno run --allow-read index.js

Average parsing time with JSON.parse: 0.041228 seconds. Total 4.122792 seconds.

> javascript@1.0.0 test:bun
> bun index.js

Average parsing time with JSON.parse: 0.006112 seconds. Total 0.611199 seconds.
```

Bun is blazingly fast™.